### PR TITLE
Change references from Google Code to Github

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -18,7 +18,7 @@ the code produced.
 
 The 'Dimensional' module and the supporting module 'NumType', both
 written in literate Haskell, follow at the end of this message. For
-a tarball and/or a current darcs repository see [1]. The code is
+a tarball and/or a current git repository see [1]. The code is
 released under a BSD3 license.
 
 Before a 1.0 release I intend to, among other thing, change the
@@ -30,7 +30,7 @@ Happy New Year!
 
 -Bjorn Buckwalter
 
-[1] http://code.google.com/p/dimensional/
+[1] https://github.com/bjornbm/dimensional
 [2] http://cgi.cse.unsw.edu.au/~dons/blog/2006/12/11#release-a-library-today
 [3] http://article.gmane.org/gmane.comp.lang.haskell.general/14671
 [4] http://www.haskell.org/haskellwiki/Dimensionalized_numbers

--- a/Numeric/Units/Dimensional.lhs
+++ b/Numeric/Units/Dimensional.lhs
@@ -449,7 +449,7 @@ that often show up in formulae. We also throw in 'pi' and 'tau' for
 good measure.
 
 The constant for zero is polymorphic as proposed by Douglas McClean
-(http://code.google.com/p/dimensional/issues/detail?id=39) allowing
+(https://github.com/bjornbm/dimensional/issues/39) allowing
 it to express zero Length or Capacitance or Velocity etc, in addition
 to the dimensionless value zero.
 

--- a/Numeric/Units/Dimensional/CGS.lhs
+++ b/Numeric/Units/Dimensional/CGS.lhs
@@ -335,5 +335,5 @@ as a template. I imagine this should be fairly straight forward.
 
 = References =
 
-[1] http://code.google.com/p/dimensional/wiki/ChuckBlake20070611
+[1] https://github.com/bjornbm/dimensional/wiki/ChuckBlake20070611
 [2] http://www.tf.uni-kiel.de/matwis/amat/mw1_ge/kap_2/basics/b2_1_14.html

--- a/dimensional.cabal
+++ b/dimensional.cabal
@@ -6,7 +6,7 @@ Copyright:           Bjorn Buckwalter 2006-2015
 Author:              Bjorn Buckwalter
 Maintainer:          bjorn@buckwalter.se
 Stability:           mostly stable
-Homepage:            http://dimensional.googlecode.com/
+Homepage:            https://github.com/bjornbm/dimensional
 Synopsis:            Statically checked physical dimensions.
 Description:
     Dimensional is a library providing data types for performing arithmetic

--- a/examples/README
+++ b/examples/README
@@ -1,2 +1,2 @@
-See the project wiki at http://dimensional.googlecode.com for more examples.
+See the project wiki at https://github.com/bjornbm/dimensional/wiki for more examples.
 

--- a/hcar/hcar2007-05.tex
+++ b/hcar/hcar2007-05.tex
@@ -23,5 +23,5 @@ hierarchy are likely to change before the 1.0 release. For more
 details see the ``Issues'' section of the project web site.
 
 \FurtherReading
- \url{http://code.google.com/p/dimensional/}
+ \url{https://github.com/bjornbm/dimensional}
 \end{hcarentry}

--- a/hcar/hcar2007-10.tex
+++ b/hcar/hcar2007-10.tex
@@ -28,6 +28,6 @@ the wiki on the project web site has a few usage examples to help
 with getting started.
 
 \FurtherReading
- \url{http://dimensional.googlecode.com}
+ \url{https://github.com/bjornbm/dimensional}
 \end{hcarentry}
 

--- a/hcar/hcar2008-05.tex
+++ b/hcar/hcar2008-05.tex
@@ -30,5 +30,5 @@ with getting started.
 The darcs repo has moved to \texttt{code.haskell.org/dimensional}.
 
 \FurtherReading
- \url{http://dimensional.googlecode.com}
+ \url{https://github.com/bjornbm/dimensional}
 \end{hcarentry}

--- a/hcar/hcar2009-05.tex
+++ b/hcar/hcar2009-05.tex
@@ -27,5 +27,5 @@ the wiki on the project web site has a few usage examples to help
 with getting started.
 
 \FurtherReading
- \url{http://dimensional.googlecode.com}
+ \url{https://github.com/bjornbm/dimensional}
 \end{hcarentry}


### PR DESCRIPTION
I wasn't so sure about changing the links in the hcar directory. The .tex files there seem to be historical, but leaving an old link there doesn't seem to serve any purpose.
